### PR TITLE
fix: downgrade logger to debug

### DIFF
--- a/src/tilt_ble/parser.py
+++ b/src/tilt_ble/parser.py
@@ -37,7 +37,7 @@ class TiltBluetoothDeviceData(BluetoothData):
         try:
             data = manufacturer_data[76]
         except KeyError:
-            _LOGGER.warning("Manufacturer ID 76 not found in data")
+            _LOGGER.debug("Manufacturer ID 76 not found in data")
             return
 
         if data[0] != 0x02 or data[1] != 0x15:


### PR DESCRIPTION
Since the user flow will enumerate all the discoveries to see
if one matches, we do not want to log at warning level since
its expected that some will not match