### PR TITLE
feat: add support for Tilt Pro sensors

### DIFF
--- a/src/tilt_ble/parser.py
+++ b/src/tilt_ble/parser.py
@@ -61,11 +61,17 @@ class TiltBluetoothDeviceData(BluetoothData):
         if not changed_manufacturer_data:
             return
 
-        temperature = major
-        specific_gravity = minor / 1000
+        tilt_pro = minor >= 5000
+
+        # up the scale ra te if a tilt pro
+        temp_scalar = 10 if tilt_pro else 1
+        grav_scalar = 10000 if tilt_pro else 1000
+
+        temperature = major / temp_scalar
+        specific_gravity = minor / grav_scalar
 
         _LOGGER.debug(
-            "Tilt %s data: temp=%.2f, gravity=%.2f, power=%.2f",
+            "Tilt %s data: temp=%.3f, gravity=%.3f, power=%.2f",
             color,
             temperature,
             specific_gravity,

--- a/src/tilt_ble/parser.py
+++ b/src/tilt_ble/parser.py
@@ -63,7 +63,7 @@ class TiltBluetoothDeviceData(BluetoothData):
 
         tilt_pro = minor >= 5000
 
-        # up the scale ra te if a tilt pro
+        # up the scale rate if a tilt pro
         temp_scalar = 10 if tilt_pro else 1
         grav_scalar = 10000 if tilt_pro else 1000
 


### PR DESCRIPTION
Tilt Pro sensors have a higher resolution than regular Tilt sensors. Reading a Pro sensor with this repository as-is results in nonsense values as they must be scaled to the higher resolution when read:

<img width="764" height="202" alt="image" src="https://github.com/user-attachments/assets/c40da870-9d51-46b3-8446-09cbe011b7d2" />

This pull request adds a switch that will scale if the found gravity is out of logical bounds, so it must be from a pro sensor.