### PR TITLE
fix: adjust device type/name for Pro models and add test

### DIFF
--- a/src/tilt_ble/parser.py
+++ b/src/tilt_ble/parser.py
@@ -52,8 +52,6 @@ class TiltBluetoothDeviceData(BluetoothData):
             return
 
         self.set_device_manufacturer("Tilt")
-        self.set_device_type(color)
-        self.set_device_name(f"Tilt {color}")
 
         (major, minor, power) = unpack(">hhb", data[18:23])
 
@@ -62,6 +60,9 @@ class TiltBluetoothDeviceData(BluetoothData):
             return
 
         tilt_pro = minor >= 5000
+
+        self.set_device_type(f"Pro {color}" if tilt_pro else color)
+        self.set_device_name(f"Tilt Pro {color}" if tilt_pro else f"Tilt {color}")
 
         # up the scale rate if a tilt pro
         temp_scalar = 10 if tilt_pro else 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -16,7 +16,7 @@ def test_can_create():
     TiltBluetoothDeviceData()
 
 
-def test_sps():
+def test_standard():
     parser = TiltBluetoothDeviceData()
     service_info = BluetoothServiceInfo(
         name="aa-bb-cc-dd-ee-ff",
@@ -73,6 +73,68 @@ def test_sps():
                 device_key=DeviceKey(key="temperature", device_id=None),
                 name="Temperature",
                 native_value=64,
+            ),
+        },
+    )
+
+
+def test_pro():
+    parser = TiltBluetoothDeviceData()
+    service_info = BluetoothServiceInfo(
+        name="aa-bb-cc-dd-ee-ff",
+        manufacturer_data={
+            76: b"\x02\x15\xa4\x95\xbb\x30\xc5\xb1\x4b\x44\xb5\x12\x13\x70\xf0\x2d\x74\xde\x02\x0e\x29\x05\xc5"
+        },
+        service_uuids=[],
+        address="aa:bb:cc:dd:ee:ff",
+        rssi=-60,
+        service_data={},
+        source="local",
+    )
+    result = parser.update(service_info)
+    assert result == SensorUpdate(
+        title=None,
+        devices={
+            None: SensorDeviceInfo(
+                name="Tilt Pro Black",
+                model="Pro Black",
+                manufacturer="Tilt",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(key="specific_gravity", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="specific_gravity", device_id=None),
+                device_class=DeviceClass.SPECIFIC_GRAVITY,
+                native_unit_of_measurement=Units.SPECIFIC_GRAVITY,
+            ),
+            DeviceKey(key="temperature", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                device_class=DeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_FAHRENHEIT,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal Strength",
+                native_value=-60,
+            ),
+            DeviceKey(key="specific_gravity", device_id=None): SensorValue(
+                device_key=DeviceKey(key="specific_gravity", device_id=None),
+                name="Specific Gravity",
+                native_value=1.0501,
+            ),
+            DeviceKey(key="temperature", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature", device_id=None),
+                name="Temperature",
+                native_value=52.6,
             ),
         },
     )


### PR DESCRIPTION
Device type for pro will now be `Pro {Color}` instead of just `{Color}`, and name will be `Tilt Pro {Color}` instead of just `Tilt {Color}`. This will help disambiguate in HA and allow you to have, for example, both a standard Green and a Pro Green connected simultaneously.